### PR TITLE
Example ECS autoscaling cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+taskcat_outputs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 taskcat_outputs/
+
+# Exclude editor configs
+.vim
+.vscode

--- a/templates/ecs-scaling-cluster/README.md
+++ b/templates/ecs-scaling-cluster/README.md
@@ -1,0 +1,8 @@
+# Example ECS Spot Cluster
+
+This template provides an example ECS Cluster using EC2 spot instances. It creates
+an AutoScalingGroup made of multiple spot instances optimized for cost.
+
+The cluster will scale in and out based on ECS target tracking. This cluster isn't
+production ready but provides an example of how this type of cluster can be done
+via CFN.

--- a/templates/ecs-scaling-cluster/template.yaml
+++ b/templates/ecs-scaling-cluster/template.yaml
@@ -1,0 +1,291 @@
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC Id for ASG instances
+    Default: vpc-5e3bff23
+
+  SubnetIds:
+    Type: CommaDelimitedList
+    Description: Comma separated list of subnet ids for ASG instances
+    Default: subnet-d43fc0e5,subnet-00389066,subnet-44c6721b
+
+  AllowedCidr:
+    Type: String
+    Description: CIDR of allowed ssh connections
+    Default: 209.37.78.5/32
+
+  LatestAmiIdx86:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id'
+
+  KeyName:
+    Type: String
+    Description: SSH key pair name
+    Default: dmichael
+
+  CPUPolicyTargetValue:
+    Type: Number
+    Description: Target CPU utilization for ASG
+    Default: 80
+
+Resources:
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets: !Ref SubnetIds
+
+  LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn: ECSServiceRole
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref  NginxTargetGroup
+      Port: 80
+      Protocol: HTTP
+
+  NginxTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: LoadBalancer
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /
+      Matcher:
+        HttpCode: 200-499
+      HealthCheckTimeoutSeconds: 9
+      HealthyThresholdCount: 2
+      Port: 80
+      Protocol: HTTP
+      ProtocolVersion: HTTP1
+      VpcId: !Ref VpcId
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow SSH
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow SSH
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref AllowedCidr
+        - SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+          IpProtocol: "-1"
+
+  LaunchTemplatex86:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        KeyName: !Ref KeyName
+        ImageId: !Ref LatestAmiIdx86
+        IamInstanceProfile:
+          Name: !Ref InstanceProfile
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash -xe
+            echo ECS_CLUSTER=${AWS::StackName}-ECSCluster >> /etc/ecs/ecs.config
+            yum install -y aws-cfn-bootstrap
+            yum update -y ecs-init
+
+            /opt/aws/bin/cfn-signal -e $? \
+              --stack ${AWS::StackName} \
+              --resource AutoScalingGroup \
+              --region ${AWS::Region}
+
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ec2.amazonaws.com]
+            Action: ["sts:AssumeRole"]
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref Role
+
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn: Cluster
+    Properties:
+      MaxSize: "8"
+      MinSize: "1"
+      DesiredCapacity: "3"
+      CapacityRebalance: true
+      VPCZoneIdentifier: !Ref SubnetIds
+      NewInstancesProtectedFromScaleIn: True
+      MetricsCollection:
+        - Granularity: 1Minute
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandBaseCapacity: 0
+          SpotAllocationStrategy: lowest-price
+          OnDemandPercentageAboveBaseCapacity: 10
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            Version: !GetAtt LaunchTemplatex86.LatestVersionNumber
+            LaunchTemplateId: !Ref LaunchTemplatex86
+          Overrides:
+            - InstanceType: t3a.nano
+            - InstanceType: t3a.micro
+            - InstanceType: t3a.small
+            - InstanceType: t3a.medium
+            - InstanceType: t3.nano
+            - InstanceType: t3.micro
+            - InstanceType: t3.small
+            - InstanceType: t3.medium
+            - InstanceType: t2.nano
+            - InstanceType: t2.micro
+            - InstanceType: t2.small
+            - InstanceType: t2.medium
+
+  CpuPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      PolicyType: TargetTrackingScaling
+      TargetTrackingConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ASGAverageCPUUtilization
+        TargetValue: !Ref CPUPolicyTargetValue
+
+  CapacityProvider:
+    Type: AWS::ECS::CapacityProvider
+    Properties:
+      AutoScalingGroupProvider:
+        AutoScalingGroupArn: !Ref AutoScalingGroup
+        ManagedScaling:
+          Status: ENABLED
+          MaximumScalingStepSize: 10
+          MinimumScalingStepSize: 1
+          TargetCapacity: 75
+        ManagedTerminationProtection: ENABLED
+
+  ClusterCapacityProviderAssociations:
+    Type: AWS::ECS::ClusterCapacityProviderAssociations
+    Properties:
+      Cluster: !Ref Cluster
+      CapacityProviders:
+        - !Ref CapacityProvider
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: !Ref CapacityProvider
+          Weight: 100
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub ${AWS::StackName}-ECSCluster
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  NginxTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Cpu: "265"
+      Memory: "128"
+      ContainerDefinitions:
+        - Name: web
+          Image: library/nginx:latest
+          PortMappings:
+            - ContainerPort: 80
+              Protocol: tcp
+
+  ECSServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+              - 'elasticloadbalancing:DeregisterInstancesFromLoadBalancer'
+              - 'elasticloadbalancing:DeregisterTargets'
+              - 'elasticloadbalancing:Describe*'
+              - 'elasticloadbalancing:RegisterInstancesWithLoadBalancer'
+              - 'elasticloadbalancing:RegisterTargets'
+              - 'ec2:Describe*'
+              - 'ec2:AuthorizeSecurityGroupIngress'
+            Resource: '*'
+
+  NginxServiceTest:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - LoadBalancerListener
+    Properties:
+      Cluster: !Ref Cluster
+      DesiredCount: 3
+      EnableECSManagedTags: true
+      LaunchType: EC2
+      SchedulingStrategy: REPLICA
+      TaskDefinition: !Ref NginxTaskDefinition
+      Role: !Ref ECSServiceRole
+      DeploymentConfiguration:
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      LoadBalancers:
+        - ContainerName: web
+          ContainerPort: 80
+          TargetGroupArn: !Ref NginxTargetGroup
+
+  NginxScalableTarget:
+      Type: AWS::ApplicationAutoScaling::ScalableTarget
+      Properties:
+        MaxCapacity: 25
+        MinCapacity: 1
+        ResourceId: !Sub service/${Cluster}/${NginxServiceTest.Name}
+        RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+        ScalableDimension: ecs:service:DesiredCount
+        ServiceNamespace: ecs
+
+  NginxScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: nginxScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref NginxScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        TargetValue: 75
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+
+Outputs:
+  LoadBalancerDNS:
+    Value: !GetAtt LoadBalancer.DNSName


### PR DESCRIPTION
This commit provides an example ECS cluster built on EC2 which will autoscaling both the service and the ASG cluster using capacity providers. The capacity provider always tries to make sure the EC2 instances have enough capacity to launch ECS tasks.